### PR TITLE
Upgrade to gRPC 1.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>8</java.version>
-		<grpc.version>1.22.1</grpc.version>
+		<grpc.version>1.23.0</grpc.version>
 		<protoc.version>3.7.1</protoc.version>
 		<reactive-grpc.version>0.10.0-RC1</reactive-grpc.version>
 		<reactor.version>3.2.5.RELEASE</reactor.version>


### PR DESCRIPTION
[This](https://github.com/grpc/grpc-java/releases/tag/v1.23.0) fixes a number of [HTTP/2 vulnerabilities](https://www.kb.cert.org/vuls/id/605641/).