### PR TITLE
Skip window entirely when invocation is cancelled

### DIFF
--- a/src/main/java/io/projectriff/processor/Processor.java
+++ b/src/main/java/io/projectriff/processor/Processor.java
@@ -310,7 +310,11 @@ public class Processor {
 
         return riffStub.invoke(Flux.concat(
                 Flux.just(start), //
-                in.map(frame -> InputSignal.newBuilder().setData(frame).build())));
+                in.map(frame -> InputSignal.newBuilder().setData(frame).build()))
+        ).onErrorResume(throwable -> {
+            System.err.printf("%s\n", throwable);
+            return Flux.empty();
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes #53

Note that this is far from ideal, as all inputs of that skipped
window are ACKed, even the valid ones that could otherwise have
been re-sent.